### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     "group:postcss",
     "group:react",
     "group:vite",
-    "security:openssf-scorecard",
+    "security:openssf-scorecard"
   ],
   "prHourlyLimit": 5,
   "addLabels": ["dependencies"],

--- a/renovate.json
+++ b/renovate.json
@@ -11,96 +11,56 @@
   "extends": [
     "config:best-practices",  
     "npm:unpublishSafe",
+    "group:allDigest",
     "group:linters",
     "group:jsTest",
     "group:postcss",
     "group:react",
     "group:vite",
-    "security:openssf-scorecard"
+    "security:openssf-scorecard",
   ],
-  "prHourlyLimit": 10,
-  "addLabels": [
-    "dependencies"
-  ],
-  "schedule": ["* 0-2 * * 1,3"],
+  "prHourlyLimit": 5,
+  "addLabels": ["dependencies"],
   "automerge": true,
-  "packageRules": [
+  "schedule": ["schedule:daily"],
+  "packageRules": [    
     {
-      "matchUpdateTypes": [
-        "major"
-      ],
+      "matchUpdateTypes": ["major"],
       "automerge": false,
       "schedule": ["* 0-2 1,15 * *"]
     },
     {
-      "groupName": "fastify packages",
+      "groupName": "group: fastify packages",
       "matchPackageNames": [
         "@fastify/{/,}**",
         "fastify{/,}**",
         "avvio{/,}**",
         "fast-json{/,}**",
         "pino{/,}**"
-      ],
-      "schedule": ["* 0-2 1,15 * *"]
-    },
-    {
-      "matchFileNames": [
-        "packages/**",
-        "servers/**",
-        "samples/**",
-        "tools/**"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "extends": [
-        "schedule:daily"
       ]
     },
     {
-      "matchUpdateTypes": [    
-        "major",
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
       "matchFileNames": [
         "eng/**",
         ".github/**",
         "docker*.yml",
         "Dockerfile*"
       ],
-      "addLabels": [
-        "eng"
-      ]
+      "addLabels": ["eng"]
     },
     {
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
       "matchFileNames": [
         "contracts/**"
       ],
-      "addLabels": [
-        "contracts"
-      ],
+      "addLabels": ["contracts"],
       "automerge": false,
+      "schedule": ["* 0-2 1,15 * *"]
     },
     {
       "matchPackageNames": [
         "aws-sdk"
       ],
-      "extends": [
-        "schedule:monthly"
-      ]
+      "extends": ["schedule:monthly"]
     },
     {
       "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -22,8 +22,16 @@
   "addLabels": [
     "dependencies"
   ],
-  "schedule": ["* 0-2 * * 7,2,4"],
+  "schedule": ["* 0-2 * * 1,3"],
+  "automerge": true,
   "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false,
+      "schedule": ["* 0-2 1,15 * *"]
+    },
     {
       "groupName": "fastify packages",
       "matchPackageNames": [
@@ -43,24 +51,11 @@
         "tools/**"
       ],
       "matchUpdateTypes": [
-        "major"
-      ],
-      "schedule": ["* 0-2 1,15 * *"]
-    },
-    {
-      "matchFileNames": [
-        "packages/**",
-        "servers/**",
-        "samples/**",
-        "tools/**"
-      ],
-      "matchUpdateTypes": [
         "minor",
         "patch",
         "pin",
         "digest"
       ],
-      "automerge": true,
       "extends": [
         "schedule:daily"
       ]
@@ -96,7 +91,8 @@
       ],
       "addLabels": [
         "contracts"
-      ]
+      ],
+      "automerge": false,
     },
     {
       "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
   "prHourlyLimit": 5,
   "addLabels": ["dependencies"],
   "automerge": true,
-  "schedule": ["schedule:daily"],
+  "schedule": ["* 0-2 * * 1,3"],
   "packageRules": [    
     {
       "matchUpdateTypes": ["major"],

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
     "group:vite",
     "security:openssf-scorecard"
   ],
-  "prHourlyLimit": 5,
+  "prHourlyLimit": 10,
   "addLabels": ["dependencies"],
   "automerge": true,
   "schedule": ["* 0-2 * * 1,3"],

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,8 @@
     "group:postcss",
     "group:react",
     "group:vite",
-    "security:openssf-scorecard"
+    "security:openssf-scorecard",
+    ":enableVulnerabilityAlertsWithLabel(security)"
   ],
   "prHourlyLimit": 10,
   "addLabels": ["dependencies"],
@@ -26,6 +27,7 @@
   "packageRules": [    
     {
       "matchUpdateTypes": ["major"],
+      "addLabels": ["major"],
       "automerge": false,
       "schedule": ["* 0-2 1,15 * *"]
     },


### PR DESCRIPTION
- Changes it to run twice weekly and automerge everything other than contracts
- Groups digest dependencies (e.g. the docker updates)
- Nodejs Major, Docker Major, & all Contract dependency updates run twice monthly and don't automerge
- Labels major and vulnerability updates